### PR TITLE
Stripe UI

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,13 +1,5 @@
-import React from "react";
-
-type AuthLayoutProps = {
-  children: React.ReactNode;
-};
-
-const AuthLayout: React.FC<AuthLayoutProps> = ({ children }) => {
-  return (
-    <div className='flex items-center justify-center h-full'>{children}</div>
-  );
+const AuthLayout = ({ children }: { children: React.ReactNode }) => {
+  return <div className="flex items-center justify-center h-full">{children}</div>;
 };
 
 export default AuthLayout;

--- a/app/(root)/(routes)/companion/[companionId]/page.tsx
+++ b/app/(root)/(routes)/companion/[companionId]/page.tsx
@@ -11,7 +11,6 @@ interface CompanionIdPageProps {
 
 const CompanionIdPage = async ({ params }: CompanionIdPageProps) => {
   const { userId } = auth();
-  // TODO: Check subscription
 
   if (!userId) return redirectToSignIn();
 

--- a/app/(root)/(routes)/settings/page.tsx
+++ b/app/(root)/(routes)/settings/page.tsx
@@ -1,0 +1,18 @@
+import SubscriptionButton from "@/components/SubscriptionButton";
+import { checkSubscription } from "@/lib/subscription";
+
+const Settings = async () => {
+  const isPro = await checkSubscription();
+
+  return (
+    <div className="h-full p-4 space-y-2">
+      <h3 className="text-lg font-medium">Settings</h3>
+      <div className="text-muted-foreground text-sm">
+        You are currently on a {isPro ? "Pro" : "Free"} plan.
+      </div>
+      <SubscriptionButton isPro={isPro} />
+    </div>
+  );
+};
+
+export default Settings;

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -9,7 +9,7 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
     <div className="h-full">
       <Navbar isPro={isPro} />
       <div className="hidden md:flex mt-16 w-20 flex-col fixed inset-y-0">
-        <Sidebar />
+        <Sidebar isPro={isPro} />
       </div>
       <main className="md:pl-20 pt-16 h-full">{children}</main>
     </div>

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -1,16 +1,13 @@
 import Sidebar from "@/components/Sidebar";
 import Navbar from "@/components/Navbar";
+import { checkSubscription } from "@/lib/subscription";
 
-import React from "react";
+const RootLayout = async ({ children }: { children: React.ReactNode }) => {
+  const isPro = await checkSubscription();
 
-type RootLayoutProps = {
-  children: React.ReactNode;
-};
-
-const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   return (
     <div className="h-full">
-      <Navbar />
+      <Navbar isPro={isPro} />
       <div className="hidden md:flex mt-16 w-20 flex-col fixed inset-y-0">
         <Sidebar />
       </div>

--- a/app/api/companion/[companionId]/route.ts
+++ b/app/api/companion/[companionId]/route.ts
@@ -2,6 +2,7 @@ import { auth, currentUser } from "@clerk/nextjs";
 import { NextResponse } from "next/server";
 
 import prismadb from "@/lib/prismadb";
+import { checkSubscription } from "@/lib/subscription";
 
 export const PATCH = async (req: Request, { params }: { params: { companionId: string } }) => {
   try {
@@ -18,7 +19,9 @@ export const PATCH = async (req: Request, { params }: { params: { companionId: s
     if (!src || !name || !description || !instructions || !seed || !categoryId)
       return new NextResponse("Missing required fields", { status: 400 });
 
-    // TODO: Check for subscription
+    const isPro = await checkSubscription();
+
+    if (!isPro) return new NextResponse("Pro subscription required", { status: 403 });
 
     const companion = await prismadb.companion.update({
       where: {

--- a/app/api/companion/route.ts
+++ b/app/api/companion/route.ts
@@ -2,6 +2,7 @@ import { currentUser } from "@clerk/nextjs";
 import { NextResponse } from "next/server";
 
 import prismadb from "@/lib/prismadb";
+import { checkSubscription } from "@/lib/subscription";
 
 export const POST = async (req: Request) => {
   try {
@@ -16,7 +17,9 @@ export const POST = async (req: Request) => {
     if (!src || !name || !description || !instructions || !seed || !categoryId)
       return new NextResponse("Missing required fields", { status: 400 });
 
-    // TODO: Check for subscription
+    const isPro = await checkSubscription();
+
+    if (!isPro) return new NextResponse("Pro subscription required", { status: 403 });
 
     const companion = await prismadb.companion.create({
       data: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,9 +3,10 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 
+import { cn } from "@/lib/utils";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Toaster } from "@/components/ui/toaster";
-import { cn } from "@/lib/utils";
+import ProModal from "@/components/ProModal";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -27,6 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             defaultTheme="system"
             enableSystem
           >
+            <ProModal />
             {children}
             <Toaster />
           </ThemeProvider>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -9,13 +9,20 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ModeToggle } from "@/components/ModeToggle";
 import MobileSidebar from "@/components/MobileSidebar";
+import { useProModal } from "@/hooks/useProModal";
 
 const font = Poppins({
   weight: "600",
   subsets: ["latin"],
 });
 
-const Navbar = () => {
+interface NavbarProps {
+  isPro: boolean;
+}
+
+const Navbar = ({ isPro }: NavbarProps) => {
+  const proModal = useProModal();
+
   return (
     <div className="fixed w-full z-50 flex justify-between items-center py-2 px-4 border-b border-primary/10 bg-secondary h-16">
       <div className="flex items-center">
@@ -32,13 +39,16 @@ const Navbar = () => {
         </Link>
       </div>
       <div className="flex items-center gap-x-3">
-        <Button
-          variant="premium"
-          size="sm"
-        >
-          Upgrade
-          <Sparkles className="h-4 w-4 fill-white text-white ml-2" />
-        </Button>
+        {!isPro && (
+          <Button
+            onClick={proModal.onOpen}
+            variant="premium"
+            size="sm"
+          >
+            Upgrade
+            <Sparkles className="h-4 w-4 fill-white text-white ml-2" />
+          </Button>
+        )}
         <ModeToggle />
         <UserButton afterSignOutUrl="/" />
       </div>

--- a/components/ProModal.tsx
+++ b/components/ProModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import axios from "axios";
+import { useState } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useProModal } from "@/hooks/useProModal";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+const ProModal = () => {
+  const proModal = useProModal();
+  const { toast } = useToast();
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const onSubscribe = async () => {
+    try {
+      setLoading(true);
+      const response = await axios.get("/api/stripe");
+
+      window.location.href = response.data.url;
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        description: `Something went wrong: ${err}`,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={proModal.isOpen}
+      onOpenChange={proModal.onClose}
+    >
+      <DialogContent>
+        <DialogHeader className="space-y-4">
+          <DialogTitle className="text-center">Upgrade to Pro</DialogTitle>
+          <DialogDescription className="text-center space-y-2">
+            Create <span className="text-sky-500 mx-1 font-medium">Custom AI</span>Companions!
+          </DialogDescription>
+        </DialogHeader>
+        <Separator />
+        <div className="flex justify-between">
+          <p className="text-2xl font-medium">
+            $9
+            <span className="text-sm font-normal">.99 / mo</span>
+          </p>
+          <Button
+            onClick={onSubscribe}
+            disabled={loading}
+            variant="premium"
+          >
+            Subscribe
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProModal;

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -4,10 +4,16 @@ import { Home, Plus, Settings } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { cn } from "@/lib/utils";
+import { useProModal } from "@/hooks/useProModal";
 
-const Sidebar = () => {
+interface SidebarProps {
+  isPro: boolean;
+}
+
+const Sidebar = ({ isPro }: SidebarProps) => {
   const pathname = usePathname();
   const router = useRouter();
+  const proModal = useProModal();
 
   const routes = [
     {
@@ -30,7 +36,7 @@ const Sidebar = () => {
     },
   ];
   const onNavigate = (url: string, pro: boolean) => {
-    // TODO: Check if PRO
+    if (pro && !isPro) return proModal.onOpen();
     return router.push(url);
   };
 

--- a/components/SubscriptionButton.tsx
+++ b/components/SubscriptionButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import axios from "axios";
+import { useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useToast } from "./ui/use-toast";
+
+interface SubscriptionButtonProps {
+  isPro: boolean;
+}
+
+const SubscriptionButton = ({ isPro = false }: SubscriptionButtonProps) => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const { toast } = useToast();
+  const onClick = async () => {
+    try {
+      setLoading(true);
+
+      const response = await axios.get("/api/stripe");
+
+      window.location.href = response.data.url;
+    } catch (err: any) {
+      toast({
+        variant: "destructive",
+        description: `Something went wrong: ${err.message}`,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+  return (
+    <Button
+      disabled={loading}
+      onClick={onClick}
+      className="sm"
+      variant={isPro ? "default" : "premium"}
+    >
+      {isPro ? "Manage Subscription" : "Upgrade"}
+      {!isPro && <Sparkles className="h-4 w-4 ml-2 fill-white" />}
+    </Button>
+  );
+};
+
+export default SubscriptionButton;

--- a/hooks/useProModal.tsx
+++ b/hooks/useProModal.tsx
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface useProModalStore {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}
+
+export const useProModal = create<useProModalStore>((set) => ({
+  isOpen: false,
+  onOpen: () => set({ isOpen: true }),
+  onClose: () => set({ isOpen: false }),
+}));

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,7 @@ import { authMiddleware } from "@clerk/nextjs";
 // Please edit this to allow other routes to be public as needed.
 // See https://clerk.com/docs/nextjs/middleware for more information about configuring your middleware
 export default authMiddleware({
-  publicRoutes: ["api/webhook"],
+  publicRoutes: ["/api/webhook"],
 });
 
 export const config = {


### PR DESCRIPTION
- fixing path of publicRoute /api/webhook within middleware.ts
- changing layout pages to be more consistent with typecasting props
- creating a useProModal custom hook, creating ProModal component to continue ux of subscribing to Pro version of app
- adding logic and prop drilling of isPro to hide Upgrade button if user is already on subscribed model
- prop drilling isPro from layout in app/(root) to Sidebar which opens ProModal if user is not a subscribed user and opens a route that is marked as a pro one (ui side protection) e.g. Create route
- adding check within POST and PATCH routes to companion to protect route if user is not subscribed and thus is unauthorized from doing so (backend side protection)
- creating Settings page which shows either a Manage Subscription or Upgrade button depending on if user is subscribed
- creating SubscriptionButton component
- removing need to be subscribed to access editing companion