### PR TITLE
small opinionated fixes

### DIFF
--- a/app/(chat)/(routes)/chat/[chatId]/page.tsx
+++ b/app/(chat)/(routes)/chat/[chatId]/page.tsx
@@ -30,7 +30,11 @@ const ChatIdPage = async ({ params }: ChatIdPageProps) => {
       },
       _count: {
         select: {
-          messages: true,
+          messages: {
+            where: {
+              userId,
+            },
+          },
         },
       },
     },

--- a/app/(root)/(routes)/page.tsx
+++ b/app/(root)/(routes)/page.tsx
@@ -1,7 +1,9 @@
+import prismadb from "@/lib/prismadb";
+import { auth, redirectToSignIn } from "@clerk/nextjs";
+
 import Categories from "@/components/Categories";
 import Companions from "@/components/Companions";
 import SearchInput from "@/components/SearchInput";
-import prismadb from "@/lib/prismadb";
 
 interface RootPageProps {
   searchParams: {
@@ -11,6 +13,10 @@ interface RootPageProps {
 }
 
 const RootPage = async ({ searchParams }: RootPageProps) => {
+  const { userId } = auth();
+
+  if (!userId) return redirectToSignIn();
+
   const data = await prismadb.companion.findMany({
     where: {
       categoryId: searchParams.categoryId,
@@ -24,7 +30,11 @@ const RootPage = async ({ searchParams }: RootPageProps) => {
     include: {
       _count: {
         select: {
-          messages: true,
+          messages: {
+            where: {
+              userId,
+            },
+          },
         },
       },
     },

--- a/components/ChatMessages.tsx
+++ b/components/ChatMessages.tsx
@@ -34,7 +34,9 @@ const ChatMessages = ({ companion, isLoading, messages = [] }: ChatMessagesProps
       <ChatMessage
         isLoading={fakeLoading}
         role="system"
-        content={`Hello, I am ${companion.name}, ${companion.description}`}
+        content={`${companion.name === "T-800" ? "" : "Hello, "}I am ${companion.name}, ${
+          companion.description
+        }`}
         src={companion.src}
       />
       {messages.map((message) => (


### PR DESCRIPTION
- modifying _count selection to only where the userId matches the messages as it was confusing to see database wide number of messages associated with a companion not match to the dialogue messages between an individual and said companion (i.e. count of messages between companion and user do not always match count of messages between all users and companions)
- changing opening dialogue ChatMessage with companion based on if talking to T-800 or not